### PR TITLE
fix a bug where multiline defaults or type annotations were dedented

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,3 @@ jobs:
         python -m pip install --upgrade tox
     - name: run
       run: tox -e py
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![ci](https://github.com/jkittner/double-indent/workflows/ci/badge.svg)](https://github.com/jkittner/double-indent/actions?query=workflow%3Aci)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/jkittner/double-indent/master.svg)](https://results.pre-commit.ci/latest/github/jkittner/double-indent/master)
-[![codecov](https://codecov.io/gh/jkittner/double-indent/branch/master/graph/badge.svg)](https://codecov.io/gh/jkittner/double-indent)
 
 # double-indent
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = double_indent
 version = 0.1.4
-description = a code formatter indenting function and mtehod definitions twice
+description = a code formatter indenting function and method definitions twice
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/jkittner/double-indent

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, pre-commit
+envlist = py38, py39, py310, py311, py312, pre-commit
 skip_missing_interpreters = true
 
 [testenv]
@@ -8,7 +8,6 @@ commands =
     coverage erase
     coverage run -m pytest -vv tests/
     coverage report --fail-under 100
-    coverage xml
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
We were not able to handle multi-line type annotation or multi-line defaults.

I was only able to fix this by also using the AST, which allowed me to find the beginning and ends of function definitions as well as of different argument types.